### PR TITLE
Remove trailing slash from /cr route

### DIFF
--- a/app/routers/rule.py
+++ b/app/routers/rule.py
@@ -20,7 +20,7 @@ class RuleError(Error):
     ruleNumber: str
 
 
-@router.get("/", summary="All Rules", response_model=Dict[str, FullRule])
+@router.get("", summary="All Rules", response_model=Dict[str, FullRule])
 async def get_all_rules(db: Session = Depends(get_db)):
     """
     Get a dictionary of all rules, keyed by their rule numbers.


### PR DESCRIPTION
Related to #30

Resolves the issue on the side of the back end server by replacing the only (non-root) route that canonically ended with a slash (`/cr`). Now we need to update the proxy config to remove trailing slashes from all routes.