### PR TITLE
Adjust MTR extractor regexes

### DIFF
--- a/app/parsing/mtr/extract_mtr.py
+++ b/app/parsing/mtr/extract_mtr.py
@@ -15,8 +15,8 @@ class ParagraphSplitter:
     line. This class takes a chunk of the parsed text and converts it to a list of actual paragraphs.
     """
 
-    url_endblock_regex = re.compile(r"\n *\n(https?://\S+ *\n?)+$")
-    hyphenated_end_regex = re.compile(r"\w(-|–|—)$")
+    url_endblock_regex = re.compile(r"\n *\n(https?://\S+ *\n?)+($|\n)")
+    hyphenated_end_regex = re.compile(r"\w([-–—])$")
 
     def __init__(self, content):
         self.content = content


### PR DESCRIPTION
Hotfix for #37.

The parsed PDF text had a link inserted in a separate paragraph in the middle of section 3.9, which wasn't caught by the URL pruning regex. It was extended to remove that link. I also made the other regex slightly more idiomatic.