### PR TITLE
Trace

### DIFF
--- a/app/database/operations.py
+++ b/app/database/operations.py
@@ -19,8 +19,8 @@ from .models import (
 )
 
 
-def get_current_cr(db: Session):
-    stmt = select(Cr.data).order_by(Cr.creation_day.desc())
+def get_current_cr(db: Session) -> Cr:
+    stmt = select(Cr).order_by(Cr.creation_day.desc())
     result = db.execute(stmt).scalars().first()
     return result
 

--- a/app/parsing/cr/refresh_cr.py
+++ b/app/parsing/cr/refresh_cr.py
@@ -81,7 +81,7 @@ async def refresh_cr(link):
             new_text, file_name = new_cr
 
             result = await extract_cr.extract(new_text)
-            diff_result = CRDiffMaker().diff(current_cr, result["rules"])
+            diff_result = CRDiffMaker().diff(current_cr.data, result["rules"])
             # TODO add to database instead?
             KeywordCache().replace(result["keywords"])
             GlossaryCache().replace(result["glossary"])

--- a/app/parsing/mtr/extract_mtr.py
+++ b/app/parsing/mtr/extract_mtr.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from tika import parser
 
-from app.utils.models import MtrChunk
+from app.utils.response_models import MtrChunk
 
 
 class ParagraphSplitter:

--- a/app/routers/diff.py
+++ b/app/routers/diff.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from ..database import operations as ops
 from ..database.db import get_db
-from ..utils.models import CRDiff, Error, MtrDiff
+from ..utils.response_models import CRDiff, Error, MtrDiff
 
 router = APIRouter()
 

--- a/app/routers/glossary_deprecated.py
+++ b/app/routers/glossary_deprecated.py
@@ -6,7 +6,7 @@ from thefuzz import fuzz, process
 
 from ..resources import static_paths as paths
 from ..resources.cache import GlossaryCache
-from ..utils.models import Error, GlossaryTerm
+from ..utils.response_models import Error, GlossaryTerm
 
 router = APIRouter()
 glossary = GlossaryCache()

--- a/app/routers/link.py
+++ b/app/routers/link.py
@@ -4,8 +4,8 @@ from sqlalchemy.orm import Session
 
 from ..database import operations as ops
 from ..database.db import get_db
-from ..utils.models import Error
 from ..utils.remove422 import no422
+from ..utils.response_models import Error
 
 router = APIRouter()
 

--- a/app/routers/metadata.py
+++ b/app/routers/metadata.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from ..database import operations as ops
 from ..database.db import get_db
 from ..database.models import Ipg, Mtr
-from ..utils.models import MtrDiffMetadataItem, PolicyMetadata
+from ..utils.response_models import MtrDiffMetadataItem, PolicyMetadata
 
 router = APIRouter(include_in_schema=False)
 

--- a/app/routers/mtr.py
+++ b/app/routers/mtr.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from app.database import operations as ops
 from app.database.db import get_db
-from app.utils.models import Error, Mtr, MtrChunk
+from app.utils.response_models import Error, Mtr, MtrChunk
 
 router = APIRouter()
 

--- a/app/routers/pending.py
+++ b/app/routers/pending.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from ..database import operations as ops
 from ..database.db import get_db
 from ..database.models import PendingCrDiff
-from ..utils.models import Error, MtrDiff, PendingCRDiffResponse
+from ..utils.response_models import Error, MtrDiff, PendingCRDiffResponse
 
 router = APIRouter(include_in_schema=False)
 

--- a/app/routers/rawfile.py
+++ b/app/routers/rawfile.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from ..database import operations as ops
 from ..database.db import get_db
 from ..database.models import Ipg, Mtr
-from ..utils.models import Error
+from ..utils.response_models import Error
 
 router = APIRouter()
 

--- a/app/routers/rule.py
+++ b/app/routers/rule.py
@@ -11,7 +11,7 @@ from ..resources import static_paths as paths
 from ..resources.cache import GlossaryCache
 from ..utils.keyword_def import get_best_rule
 from ..utils.remove422 import no422
-from ..utils.response_models import Error, Example, FullRule, GlossaryTerm, KeywordDict, Rule
+from ..utils.response_models import Error, Example, FullRule, GlossaryTerm, KeywordDict, Rule, TraceItem
 from ..utils.trace import create_cr_trace
 
 router = APIRouter()
@@ -187,11 +187,35 @@ async def get_examples(
     return {"ruleNumber": rule_id, "examples": rule["examples"]}
 
 
-@router.get("/trace/{rule_id}", summary="Trace", response_model=Union[list])
+@router.get(
+    "/trace/{rule_id}",
+    summary="Trace",
+    response_model=list[TraceItem],
+    responses={
+        404: {"description": "Rule was not found", "model": RuleError},
+        200: {"description": "Full trace for the requested rule"},
+    },
+)
+@no422
 def get_trace(
     rule_id: str = Path(description="Current number of the rule you want to trace."),
     db: Session = Depends(get_db),
 ):
+    """
+    Get the trace of a rule.
+
+    Given a current rule, its trace is a list (in reverse chronological order) of all changes that rule went through.
+    Each change can correspond to one of several actions (denoted by the `action` field):
+    - `created`: The rule was first created.
+    - `moved`: The rule changed numbers, but its text staid the same.
+    - `edited`: The rule changed text, but its number staid the same.
+    - `replaced`: Both the rule number and the rule text changed.
+
+    For all actions except `moved`, the change has `old` and `new` fields with the same format as
+    those returned in the CR diffs. For `moved`, the `ruleText` of those fields is missing.
+
+    Each change also contains a `diff` field containing the set codes of the diff it comes from.
+    """
     current_cr = ops.get_current_cr(db)
     current_rule = current_cr.data.get(rule_id)
     if not current_rule:

--- a/app/routers/rule_deprecated.py
+++ b/app/routers/rule_deprecated.py
@@ -8,8 +8,8 @@ from ..database import operations as ops
 from ..database.db import get_db
 from ..resources import static_paths as paths
 from ..utils.keyword_def import get_best_rule
-from ..utils.models import Error, Example, FullRule, KeywordDict, Rule
 from ..utils.remove422 import no422
+from ..utils.response_models import Error, Example, FullRule, KeywordDict, Rule
 
 router = APIRouter()
 
@@ -97,7 +97,7 @@ async def get_all_rules(db: Session = Depends(get_db)):
     and next rule in the document.
     """
     rules = ops.get_current_cr(db)
-    return rules
+    return rules.data
 
 
 @router.get("/keywords", summary="Keywords", response_model=KeywordDict)

--- a/app/routers/unofficial_glossary_deprecated.py
+++ b/app/routers/unofficial_glossary_deprecated.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 from app.resources import static_paths as paths
-from app.utils.models import GlossaryTerm
+from app.utils.response_models import GlossaryTerm
 
 router = APIRouter()
 

--- a/app/utils/response_models.py
+++ b/app/utils/response_models.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import Enum
 
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass
@@ -58,26 +59,14 @@ class GlossaryTerm:
 
 @dataclass(config=Config)
 class CRDiffRule:
-    ruleNum: str
-    ruleText: str
+    ruleNum: str = Field(..., alias="ruleNumber")
+    ruleText: str = Field(...)
 
 
 @dataclass(config=Config)
 class CRDiffItem(BaseModel):
     old: CRDiffRule | None
     new: CRDiffRule | None
-
-
-@dataclass(config=Config)
-class CRDiffNavItem:
-    old: str
-    new: str
-
-
-@dataclass(config=Config)
-class CRDiffNav:
-    prev: CRDiffNavItem | None
-    next: CRDiffNavItem | None
 
 
 @dataclass(config=Config)
@@ -156,3 +145,30 @@ class PolicyMetadata:
 @dataclass(config=Config)
 class MtrDiffMetadataItem:
     effective_date: datetime.date = Field(..., alias="effectiveDate")
+
+
+class TraceItemAction(str, Enum):
+    created = "created"
+    edited = "edited"
+    replaced = "replaced"
+    moved = "moved"
+
+
+@dataclass(config=Config)
+class DiffSetCodes:
+    sourceCode: str
+    destCode: str
+
+
+@dataclass(config=Config)
+class TraceDiffRule:
+    ruleNum: str = Field(..., alias="ruleNumber")
+    ruleText: str | None = Field(None)
+
+
+@dataclass(config=Config)
+class TraceItem:
+    action: TraceItemAction
+    old: TraceDiffRule | None
+    new: TraceDiffRule
+    diff: DiffSetCodes

--- a/app/utils/trace.py
+++ b/app/utils/trace.py
@@ -1,0 +1,72 @@
+from sqlalchemy.orm import Session
+
+import app.database.operations as ops
+from app.database.models import CrDiff
+from app.utils.response_models import DiffSetCodes, TraceDiffRule, TraceItem, TraceItemAction
+
+
+def create_cr_trace(db: Session, rule_id: str) -> list[TraceItem]:
+    trace = []
+    current_diff = ops.get_cr_diff(db, None, None)
+    while current_diff:
+        change = try_get_diff_change(current_diff, rule_id)
+        if change:
+            trace.append(change)
+            if change.action == TraceItemAction.created:
+                break
+            rule_id = change.old.ruleNum
+
+        current_diff = ops.get_cr_diff(db, None, current_diff.source.set_code)
+
+    return trace
+
+
+def try_get_diff_change(diff: CrDiff, rule_id: str) -> TraceItem | None:
+    change = changes_to_trace_item(diff, rule_id) or moves_to_trace_item(diff, rule_id) or None
+    if not change:
+        return None
+
+    return change
+
+
+def moves_to_trace_item(diff: CrDiff, rule_id: str) -> TraceItem | None:
+    matched_move = [m for m in diff.moves if m[1] == rule_id]
+    if not matched_move:
+        return None
+
+    match = matched_move[0]
+    return TraceItem(
+        action=TraceItemAction.moved,
+        old=TraceDiffRule(ruleNum=match[0], ruleText=None),
+        new=TraceItemAction(ruleNum=match[1], ruleText=None),
+        diff=get_trace_diff_metadata(diff),
+    )
+
+
+def changes_to_trace_item(diff: CrDiff, rule_id: str) -> TraceItem | None:
+    matched_change = [c for c in diff.changes if c["new"] and c["new"]["ruleNum"] == rule_id]
+    if not matched_change:
+        return None
+
+    match = matched_change[0]
+    old = TraceDiffRule(**match["old"]) if match.get("old") else None
+    return TraceItem(
+        action=get_change_action(match),
+        old=old,
+        new=TraceDiffRule(ruleNum=match["new"]["ruleNum"], ruleText=match["new"]["ruleText"]),
+        diff=get_trace_diff_metadata(diff),
+    )
+
+
+def get_change_action(change) -> TraceItemAction:
+    if not change.get("old"):
+        return TraceItemAction.created
+    if change["old"]["ruleNum"] == change["new"]["ruleNum"]:
+        return TraceItemAction.edited
+    if not change["old"].get("ruleText") and not change["new"].get("ruleText"):
+        return TraceItemAction.moved
+    return TraceItemAction.replaced
+
+
+def get_trace_diff_metadata(diff: CrDiff) -> DiffSetCodes:
+    return DiffSetCodes(sourceCode=diff.source.set_code, destCode=diff.dest.set_code)


### PR DESCRIPTION
Resolves #9.

Adds endpoint for getting the trace of a (current) rule. Currently a pretty cured solution, but should be OK for low usage. #50 should probably set a separate lower limit for this endpoint.

It also changes `ruleNum` in the response for CR diffs into `ruleNumber` (through an alias, the database schema stays the same).