### PR TITLE
Table of contents + Trace updates

### DIFF
--- a/app/database/models.py
+++ b/app/database/models.py
@@ -13,6 +13,7 @@ class Cr(Base):
     set_code = Column(String(5))
     set_name = Column(String(50))
     data = Column(JSONB(astext_type=Text()))
+    toc = Column(JSONB(astext_type=Text()))
     file_name = Column(Text)
 
 
@@ -22,6 +23,7 @@ class PendingCr(Base):
     id = Column(Integer, primary_key=True)
     creation_day = Column(Date)
     data = Column(JSONB(astext_type=Text()))
+    toc = Column(JSONB(astext_type=Text()))
     file_name = Column(Text)
 
 

--- a/app/database/operations.py
+++ b/app/database/operations.py
@@ -101,6 +101,7 @@ def apply_pending_cr_and_diff(db: Session, set_code: str, set_name: str) -> None
         set_name=set_name,
         set_code=set_code,
         file_name=pendingCr.file_name,
+        toc=pendingCr.toc,
     )
     newDiff = CrDiff(
         creation_day=pendingDiff.creation_day,
@@ -182,8 +183,10 @@ def get_mtr_diff_metadata(db: Session):
     return db.execute(stmt).fetchall()
 
 
-def set_pending_cr_and_diff(db: Session, new_rules: dict, new_diff: list, file_name: str, new_moves: list):
-    new_cr = PendingCr(creation_day=datetime.date.today(), data=new_rules, file_name=file_name)
+def set_pending_cr_and_diff(
+    db: Session, new_rules: dict, new_toc: list, new_diff: list, file_name: str, new_moves: list
+):
+    new_cr = PendingCr(creation_day=datetime.date.today(), data=new_rules, file_name=file_name, toc=new_toc)
     curr_cr_id: Cr = db.execute(select(Cr.id).order_by(Cr.creation_day.desc())).scalars().first()
     new_diff = PendingCrDiff(
         creation_day=datetime.date.today(), source_id=curr_cr_id, dest=new_cr, changes=new_diff, moves=new_moves

--- a/app/parsing/cr/refresh_cr.py
+++ b/app/parsing/cr/refresh_cr.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from dataclasses import asdict
 
 import requests
 
@@ -85,7 +86,14 @@ async def refresh_cr(link):
             # TODO add to database instead?
             KeywordCache().replace(result["keywords"])
             GlossaryCache().replace(result["glossary"])
-            ops.set_pending_cr_and_diff(session, result["rules"], diff_result.diff, file_name, diff_result.moved)
+            ops.set_pending_cr_and_diff(
+                session,
+                result["rules"],
+                [asdict(s) for s in result["toc"]],
+                diff_result.diff,
+                file_name,
+                diff_result.moved,
+            )
 
 
 if __name__ == "__main__":

--- a/app/routers/diff.py
+++ b/app/routers/diff.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from ..database import operations as ops
 from ..database.db import get_db
-from ..utils.response_models import CRDiff, Error, MtrDiff
+from ..utils.response_models import CRDiff, CRMoveItem, Error, MtrDiff
 
 router = APIRouter()
 
@@ -47,9 +47,10 @@ async def cr_diff(
     was a reference to a renumbered rule.
 
     The `moves` property contains an ordered array representing the rules that changed their number but didn't change
-    their content. This property may be `null` or missing. If present, each element in the array is a two-item tuple
-    of strings, containing the old and new numbers for the given rule. No items that are part of the `changes`
-    property are included here. In particular, this means that both elements of each two-tuple are always valid strings.
+    their content. This property may be `null` or missing. If present, each element in the array is a dictionary with
+    strings describing `from` which number `to` which number the rule moved. of strings, containing the old and new
+    numbers for the given rule. No items that are part of the `changes` property are included here. In particular,
+    this means that both values are always present and not `null` nor empty.
 
     `sourceSet` and `destSet` contain full names of the sets being diffed, and `sourceCode` and `destCode` contain
     the canonical set codes of those sets.
@@ -73,7 +74,7 @@ async def cr_diff(
         "sourceCode": diff.source.set_code,
         "destSet": diff.dest.set_name,
         "destCode": diff.dest.set_code,
-        "moves": diff.moves,
+        "moves": [CRMoveItem(from_number=f, to_number=t) for f, t in diff.moves],
     }
 
 

--- a/app/routers/rule.py
+++ b/app/routers/rule.py
@@ -214,7 +214,8 @@ def get_trace(
     For all actions except `moved`, the change has `old` and `new` fields with the same format as
     those returned in the CR diffs. For `moved`, the `ruleText` of those fields is missing.
 
-    Each change also contains a `diff` field containing the set codes of the diff it comes from.
+    Each change also contains a `diff` field containing information about the sets that are in the diff containing
+    that change.
     """
     current_cr = ops.get_current_cr(db)
     current_rule = current_cr.data.get(rule_id)

--- a/app/routers/rule.py
+++ b/app/routers/rule.py
@@ -11,7 +11,7 @@ from ..resources import static_paths as paths
 from ..resources.cache import GlossaryCache
 from ..utils.keyword_def import get_best_rule
 from ..utils.remove422 import no422
-from ..utils.response_models import Error, Example, FullRule, GlossaryTerm, KeywordDict, Rule, TraceItem
+from ..utils.response_models import Error, Example, FullRule, GlossaryTerm, KeywordDict, Rule, ToCSection, TraceItem
 from ..utils.trace import create_cr_trace
 
 router = APIRouter()
@@ -54,6 +54,20 @@ def get_glossary():
     entry and the values contain the actual name of the entry and its content
     """
     return FileResponse(paths.glossary_dict)
+
+
+@router.get("/toc", summary="Table of Contents", response_model=list[ToCSection])
+def get_table_of_contents(db: Session = Depends(get_db)):
+    """
+    Get the CR table of contents. The table of contents is an ordered list of sections. Each section has a number
+    (`1`) and a title (`"Game Concepts"`), as well as a list of subsections. Each subsection has a number (`105`) and
+    a title ( `"Colors"`).
+
+    The table of contents includes only numbered sections in the CR. That means it doesn't contain entries for the
+    introduction, the glossary, or the credits.
+    """
+    cr = ops.get_current_cr(db)
+    return cr.toc
 
 
 @router.get(

--- a/app/utils/response_models.py
+++ b/app/utils/response_models.py
@@ -76,12 +76,16 @@ class CRMoveItem:
 
 
 @dataclass(config=Config)
-class CRDiff:
-    creation_day: datetime.date = Field(..., alias="creationDay")
+class CRDiffMetadata:
     source_set: str = Field(..., alias="sourceSet")
     source_code: str = Field(..., alias="sourceCode")
     dest_set: str = Field(..., alias="destSet")
     dest_code: str = Field(..., alias="destCode")
+
+
+@dataclass(config=Config)
+class CRDiff(CRDiffMetadata):
+    creation_day: datetime.date = Field(..., alias="creationDay")
     changes: list[CRDiffItem] = Field(...)
     moves: list[CRMoveItem] = Field(description="List of moved rules")
 
@@ -177,4 +181,4 @@ class TraceItem:
     action: TraceItemAction
     old: TraceDiffRule | None
     new: TraceDiffRule
-    diff: DiffSetCodes
+    diff: CRDiffMetadata

--- a/app/utils/response_models.py
+++ b/app/utils/response_models.py
@@ -70,6 +70,12 @@ class CRDiffItem(BaseModel):
 
 
 @dataclass(config=Config)
+class CRMoveItem:
+    from_number: str = Field(..., alias="from")
+    to_number: str = Field(..., alias="to")
+
+
+@dataclass(config=Config)
 class CRDiff:
     creation_day: datetime.date = Field(..., alias="creationDay")
     source_set: str = Field(..., alias="sourceSet")
@@ -77,7 +83,7 @@ class CRDiff:
     dest_set: str = Field(..., alias="destSet")
     dest_code: str = Field(..., alias="destCode")
     changes: list[CRDiffItem] = Field(...)
-    moves: list[tuple[str, str]] = Field(description="List of moved rules")
+    moves: list[CRMoveItem] = Field(description="List of moved rules")
 
 
 @dataclass(config=Config)

--- a/app/utils/response_models.py
+++ b/app/utils/response_models.py
@@ -58,6 +58,19 @@ class GlossaryTerm:
 
 
 @dataclass(config=Config)
+class ToCSubsection:
+    number: int
+    title: str
+
+
+@dataclass(config=Config)
+class ToCSection:
+    number: int
+    title: str
+    subsections: list[ToCSubsection]
+
+
+@dataclass(config=Config)
 class CRDiffRule:
     ruleNum: str = Field(..., alias="ruleNumber")
     ruleText: str = Field(...)

--- a/app/utils/trace.py
+++ b/app/utils/trace.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 
 import app.database.operations as ops
 from app.database.models import CrDiff
-from app.utils.response_models import DiffSetCodes, TraceDiffRule, TraceItem, TraceItemAction
+from app.utils.response_models import CRDiffMetadata, TraceDiffRule, TraceItem, TraceItemAction
 
 
 def create_cr_trace(db: Session, rule_id: str) -> list[TraceItem]:
@@ -68,5 +68,10 @@ def get_change_action(change) -> TraceItemAction:
     return TraceItemAction.replaced
 
 
-def get_trace_diff_metadata(diff: CrDiff) -> DiffSetCodes:
-    return DiffSetCodes(sourceCode=diff.source.set_code, destCode=diff.dest.set_code)
+def get_trace_diff_metadata(diff: CrDiff) -> CRDiffMetadata:
+    return CRDiffMetadata(
+        source_code=diff.source.set_code,
+        source_set=diff.source.set_name,
+        dest_code=diff.dest.set_code,
+        dest_set=diff.dest.set_name,
+    )


### PR DESCRIPTION
Resolves #27. Related to #9.

Adds parsing for the CR ToC and a `/cr/toc` endpoint to serve it. Also changes up the format of `cr/trace` and `diff/cr` a bit