### PR TITLE
Enable keyword redirection for trace

### DIFF
--- a/src/cr/keyword_def.py
+++ b/src/cr/keyword_def.py
@@ -8,7 +8,7 @@ ability_words_rule = "207.2c"
 
 # is just rule definition (ends with a number) - we want subrules
 definition = r".*\d$"
-# is just a single sentence (only one comma) and includes "is a(n)"
+# is just a single sentence (only one period) and includes "is a(n)"
 single_sentence = r"^([^.]*\bis an?\b[^.]*\.)$"
 # should be skipped because reasons
 exceptions = ["702.57a", "702.22b"]
@@ -34,7 +34,7 @@ def get_keyword_definition(db, rule_id):
         if not next_rule:
             break  # stop at the end of the road
         next_rule = cr_service.get_rule(db, next_rule)
-        if re.match(definition, next_rule["ruleNumber"]):
+        if not next_rule or re.match(definition, next_rule["ruleNumber"]):
             break  # stop at the end of the rule
         rule = next_rule
     return rule

--- a/src/cr/schemas.py
+++ b/src/cr/schemas.py
@@ -75,3 +75,8 @@ class TraceItem(ResponseModel):
     old: TraceDiffRule | None = None
     new: TraceDiffRule
     diff: CrDiffMetadata
+
+
+class Trace(ResponseModel):
+    ruleNumber: str = Field(..., description="Number of the rule for which the trace was generated.")
+    items: list[TraceItem] = Field(..., description="List of changes made to the rule, in reverse chronological order.")

--- a/src/cr/service.py
+++ b/src/cr/service.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from src.cr import utils
 from src.cr.models import Cr
-from src.cr.schemas import TraceItem
+from src.cr.schemas import Trace
 from src.diffs.models import CrDiff, CrDiffItem
 from src.diffs.schemas import CrDiffMetadata
 
@@ -27,9 +27,9 @@ def get_cr_metadata(db: Session):
     return db.execute(select(Cr.creation_day, Cr.set_code, Cr.set_name).order_by(Cr.creation_day.desc())).fetchall()
 
 
-def get_cr_trace(db: Session, rule_number: str) -> list[TraceItem]:
+def get_cr_trace(db: Session, rule_number: str) -> Trace:
     items = get_cr_trace_items(db, rule_number) or []
-    return [utils.format_trace_item(item) for item in items]
+    return Trace(ruleNumber=rule_number, items=[utils.format_trace_item(item) for item in items])
 
 
 def get_cr_trace_items(db: Session, rule_number: str) -> list[CrDiffItem] | None:


### PR DESCRIPTION
BREAKING CHANGE: Changed `/cr/trace` response format.
BREAKING CHANGE: Changed default behavior for definition search in `/cr/{rule_id}`

If the trace endpoint is called with a keyword rule, it now supports redirection to the actual definition of that rule, same as the rule endpoint. This necessitated the change of the response from an array to a dict, so that we can send the actual rule that was queried.

I also changed the default of the rule endpoint to *not* default to definition redirection in order to be consistent with the rest of the API.
