### PR TITLE
Read proxy headers in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN poetry install --no-interaction --no-cache --without dev
 
 # Run app
 COPY src /code/src
-CMD ["poetry", "run", "uvicorn", "src.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "80"]
+CMD ["poetry", "run", "uvicorn", "src.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
The proxy headers are only accepted from the default localhost, which can cause incorrect redirects in certain deployments. The container should always be deployed behind a reverse proxy anyways, so there should be no harm in accepting the headers from anywhere (making it the responsibility of the proxy to set them correctly).
