### PR TITLE
Update rule mention regex

### DIFF
--- a/src/difftool/itemdiffer.py
+++ b/src/difftool/itemdiffer.py
@@ -43,8 +43,8 @@ class CRItemDiffer(ItemDiffer):
         if not rule_slice:
             return False
         rule_regex = r"(?:\d{3}(?:\.\d+[a-z]?)?)"
-        rule_mention_regex = r"(?:rule )?" + rule_regex + r"\)?[,.]?"
-        rule_mention_range_regex = r"(?:rules )?" + rule_regex + r"–(?:[a-z]|" + rule_regex + r")\)?[,.]?"
+        rule_mention_regex = r"(?:rule )?" + rule_regex + r"\.?\)?[,.]?"
+        rule_mention_range_regex = r"(?:rules )?" + rule_regex + r"–(?:[a-z]|" + rule_regex + r")\.?\)?[,.]?"
         text = " ".join(rule_slice)
         return not re.fullmatch(rule_mention_regex, text) and not re.fullmatch(rule_mention_range_regex, text)
 


### PR DESCRIPTION
The regex for checking whether a change is just a reference to a renumbered rule handles cases such as "[...] (see rule 104.3a)."

Some of these are not written as a part of the sentence though, and asa such are punctuated differently, i.e. "[...]. (See rule 104.3a.)"

Having the period inside the parentheses isn't supported by the matching regex, so I'm updating it to properly detect such references as well.
