### PR TITLE
Claude/elastic banzai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-interaction --no-cache --without dev
 
 
-# Run app
+# Copy application code
+COPY alembic /code/alembic
+COPY alembic.ini /code/alembic.ini
 COPY src /code/src
-CMD ["poetry", "run", "uvicorn", "src.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "80"]
+COPY entrypoint.sh /code/entrypoint.sh
+
+CMD ["/code/entrypoint.sh"]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -2,6 +2,7 @@ import os
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import URL
 
 from alembic import context
 from src.models import get_full_base
@@ -28,11 +29,13 @@ target_metadata = get_full_base().metadata
 
 
 def get_url():
-    user = os.getenv("DB_USER", "server")
-    password = os.getenv("DB_PASS", "password")
-    server = os.getenv("DB_HOST", "localhost")
-    db = os.getenv("DB_DATABASE", "academy_ruins")
-    return f"postgresql://{user}:{password}@{server}/{db}"
+    return URL.create(
+        "postgresql",
+        username=os.getenv("DB_USER", "server"),
+        password=os.getenv("DB_PASS", "password"),
+        host=os.getenv("DB_HOST", "localhost"),
+        database=os.getenv("DB_DATABASE", "academy_ruins"),
+    )
 
 
 def run_migrations_offline() -> None:

--- a/alembic/versions/a1b2c3d4e5f6_add_creation_day_indexes.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_creation_day_indexes.py
@@ -1,0 +1,24 @@
+"""add_creation_day_indexes
+
+Revision ID: a1b2c3d4e5f6
+Revises: f81d76ccde31
+Create Date: 2024-01-01 00:00:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "f81d76ccde31"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(op.f("ix_cr_creation_day"), "cr", ["creation_day"], unique=False)
+    op.create_index(op.f("ix_cr_diffs_creation_day"), "cr_diffs", ["creation_day"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_cr_diffs_creation_day"), table_name="cr_diffs")
+    op.drop_index(op.f("ix_cr_creation_day"), table_name="cr")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,12 @@ services:
     image: postgres
     restart: always
     ports:
-      - 5432:5432
+      - "127.0.0.1:5432:5432"
     environment:
+      # Change this in production
       POSTGRES_PASSWORD: password
 
   tika:
     image: apache/tika
     ports:
-      - 9998:9998
+      - "127.0.0.1:9998:9998"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
     volumes:
       - ./src:/code/src:rw
       - ./generated:/code/src/resources/generated:rw
+    depends_on:
+      - db
+      - tika
 
   db:
     image: postgres

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for database..."
+while ! python -c "
+from src.db import engine
+engine.connect().close()
+" 2>/dev/null; do
+    sleep 2
+done
+echo "Database is ready"
+
+echo "Running migrations..."
+poetry run alembic upgrade head
+
+echo "Running bootstrap (skips if already seeded)..."
+poetry run academyruins bootstrap
+
+echo "Starting API server..."
+exec poetry run uvicorn src.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 80

--- a/src/admin/router.py
+++ b/src/admin/router.py
@@ -1,6 +1,7 @@
 import os
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
 from src.admin import service
@@ -12,15 +13,17 @@ from src.schemas import ResponseModel
 
 router = APIRouter(include_in_schema=False)
 
+_bearer = HTTPBearer()
 
-@router.get("/admin/update-link/{doctype}")
-def update_cr(
-    doctype: str, token: str, response: Response, background_tasks: BackgroundTasks, db: Session = Depends(get_db)
-):
+
+def verify_admin_token(credentials: HTTPAuthorizationCredentials = Depends(_bearer)):
+    if credentials.credentials != os.environ["ADMIN_KEY"]:
+        raise HTTPException(403, "Incorrect admin key")
+
+
+@router.get("/admin/update-link/{doctype}", dependencies=[Depends(verify_admin_token)])
+def update_cr(doctype: str, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
     doctype = doctype.lower()
-    if token != os.environ["ADMIN_KEY"]:
-        response.status_code = 403
-        return {"detail": "Incorrect admin key"}
 
     new_link = service.apply_pending_redirect(db, doctype)
     if not new_link:
@@ -41,21 +44,15 @@ class Confirm(ResponseModel):
     code: str
 
 
-@router.post("/admin/confirm/cr")
-def confirm_cr(body: Confirm, token: str, response: Response, db: Session = Depends(get_db)):
-    if token != os.environ["ADMIN_KEY"]:  # TODO replace with better auth scheme
-        response.status_code = 403
-        return {"detail": "Incorrect admin key"}
-
+@router.post("/admin/confirm/cr", dependencies=[Depends(verify_admin_token)])
+def confirm_cr(body: Confirm, db: Session = Depends(get_db)):
     service.apply_pending_cr_and_diff(db, body.code, body.name)
     db.commit()
     return {"detail": "success"}
 
 
-@router.post("/admin/confirm/mtr")
-def confirm_mtr(token: str, db: Session = Depends(get_db)):
-    if token != os.environ["ADMIN_KEY"]:
-        raise HTTPException(403, "Incorrect admin key")
+@router.post("/admin/confirm/mtr", dependencies=[Depends(verify_admin_token)])
+def confirm_mtr(db: Session = Depends(get_db)):
     service.apply_pending_mtr_and_diff(db)
     db.commit()
     return {"detail": "success"}

--- a/src/admin/router.py
+++ b/src/admin/router.py
@@ -46,13 +46,15 @@ class Confirm(ResponseModel):
 
 @router.post("/admin/confirm/cr", dependencies=[Depends(verify_admin_token)])
 def confirm_cr(body: Confirm, db: Session = Depends(get_db)):
-    service.apply_pending_cr_and_diff(db, body.code, body.name)
+    if not service.apply_pending_cr_and_diff(db, body.code, body.name):
+        raise HTTPException(400, "No pending CR to confirm")
     db.commit()
     return {"detail": "success"}
 
 
 @router.post("/admin/confirm/mtr", dependencies=[Depends(verify_admin_token)])
 def confirm_mtr(db: Session = Depends(get_db)):
-    service.apply_pending_mtr_and_diff(db)
+    if not service.apply_pending_mtr_and_diff(db):
+        raise HTTPException(400, "No pending MTR to confirm")
     db.commit()
     return {"detail": "success"}

--- a/src/admin/service.py
+++ b/src/admin/service.py
@@ -23,9 +23,11 @@ def apply_pending_redirect(db: Session, resource: str) -> str | None:
     return ret
 
 
-def apply_pending_cr_and_diff(db: Session, set_code: str, set_name: str) -> None:
-    pendingCr: PendingCr = db.execute(select(PendingCr)).scalar_one()
-    pendingDiff: PendingCrDiff = db.execute(select(PendingCrDiff)).scalar_one()
+def apply_pending_cr_and_diff(db: Session, set_code: str, set_name: str) -> bool:
+    pendingCr: PendingCr | None = db.execute(select(PendingCr)).scalar_one_or_none()
+    pendingDiff: PendingCrDiff | None = db.execute(select(PendingCrDiff)).scalar_one_or_none()
+    if not pendingCr or not pendingDiff:
+        return False
     diff_items = [CrDiffItem.from_change(x) for x in pendingDiff.changes]
     diff_items += [CrDiffItem.from_move(x) for x in pendingDiff.moves]
     newCr = Cr(
@@ -46,11 +48,14 @@ def apply_pending_cr_and_diff(db: Session, set_code: str, set_name: str) -> None
     db.add(newDiff)
     db.delete(pendingCr)
     db.delete(pendingDiff)
+    return True
 
 
-def apply_pending_mtr_and_diff(db: Session):
-    pending: PendingMtr = get_pending_mtr(db)
-    pending_diff: PendingMtrDiff = db.execute(select(PendingMtrDiff)).scalar_one()
+def apply_pending_mtr_and_diff(db: Session) -> bool:
+    pending: PendingMtr | None = get_pending_mtr(db)
+    pending_diff: PendingMtrDiff | None = db.execute(select(PendingMtrDiff)).scalar_one_or_none()
+    if not pending or not pending_diff:
+        return False
     mtr = Mtr(
         file_name=pending.file_name,
         creation_day=pending.creation_day,
@@ -64,3 +69,4 @@ def apply_pending_mtr_and_diff(db: Session):
     db.delete(pending)
     db.add(diff)
     db.delete(pending_diff)
+    return True

--- a/src/admin/service.py
+++ b/src/admin/service.py
@@ -2,6 +2,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.cr.models import Cr, PendingCr
+from src.cr.service import invalidate_cr_cache
 from src.diffs.models import CrDiff, CrDiffItem, MtrDiff, PendingCrDiff, PendingMtrDiff
 from src.link.models import PendingRedirect, Redirect
 from src.mtr.models import Mtr, PendingMtr
@@ -48,6 +49,7 @@ def apply_pending_cr_and_diff(db: Session, set_code: str, set_name: str) -> bool
     db.add(newDiff)
     db.delete(pendingCr)
     db.delete(pendingDiff)
+    invalidate_cr_cache()
     return True
 
 

--- a/src/cli_scripts/bootstrap.py
+++ b/src/cli_scripts/bootstrap.py
@@ -1,0 +1,186 @@
+"""
+Bootstrap the database from scratch with zero human intervention.
+
+Downloads the current CR, MTR, and IPG from WotC, parses them,
+and inserts the initial rows directly (bypassing the pending/confirm flow
+since there's no previous version to diff against).
+"""
+
+import datetime
+import os
+import re
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+from sqlalchemy import select
+
+from src.cr.models import Cr
+from src.db import SessionLocal
+from src.extractor.cr import extract_cr
+from src.extractor.cr.refresh_cr import download_cr, get_response_text
+from src.extractor.download_doc import download_doc
+from src.ipg.models import Ipg
+from src.link.models import Redirect
+from src.mtr.models import Mtr
+from src.resources import static_paths as paths
+from src.resources.cache import GlossaryCache, KeywordCache
+from src.resources.seeder import seed
+from src.scraper.cr_scraper import is_txt_link, rules_page_uri
+from src.scraper.docs_scraper import docs_page_uri, get_links_from_html
+from src.utils.logger import logger
+
+
+def _scrape_cr_link() -> str | None:
+    """Scrape the current CR .txt link from WotC's rules page."""
+    response = requests.get(rules_page_uri)
+    if not response.ok:
+        logger.error(f"Couldn't fetch rules page (code {response.status_code})")
+        return None
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    txt_links = soup.find_all(is_txt_link)
+    if len(txt_links) != 1:
+        logger.error(f"Wrong number of TXT links found (expected 1, got {len(txt_links)})")
+        return None
+
+    href = txt_links[0]["href"]
+    return href.replace(" ", "%20")
+
+
+def _scrape_doc_links() -> dict[str, str]:
+    """Scrape current MTR/IPG/JAR links from WPN docs page."""
+    response = requests.get(docs_page_uri)
+    if not response.ok:
+        logger.error(f"Couldn't fetch WPN docs page (code {response.status_code})")
+        return {}
+
+    return get_links_from_html(response.text)
+
+
+def _seed_redirect(db, resource: str, link: str):
+    """Insert a redirect directly into the active table."""
+    existing = db.get(Redirect, resource)
+    if existing:
+        existing.link = link
+    else:
+        db.add(Redirect(resource=resource, link=link))
+
+
+def _bootstrap_cr(db, cr_link: str) -> bool:
+    """Download, parse, and insert the first CR directly."""
+    result = download_cr(cr_link)
+    if result is None:
+        logger.error("Failed to download CR")
+        return False
+
+    text, file_name = result
+    parsed = extract_cr.extract(text)
+
+    cr = Cr(
+        creation_day=datetime.date.today(),
+        set_code="SEED",
+        set_name="Bootstrap Seed",
+        data=parsed["rules"],
+        toc=[s.model_dump() for s in parsed["toc"]],
+        file_name=file_name,
+    )
+    db.add(cr)
+
+    # Write cache files
+    KeywordCache().replace(parsed["keywords"])
+    GlossaryCache().replace(parsed["glossary"])
+
+    logger.info("Bootstrapped CR successfully")
+    return True
+
+
+def _bootstrap_mtr(db, mtr_link: str) -> bool:
+    """Download, parse, and insert the first MTR directly."""
+    if os.environ.get("USE_TIKA") != "1":
+        logger.warning("Tika not enabled (USE_TIKA != 1), skipping MTR bootstrap")
+        return False
+
+    from src.extractor.mtr.extract_mtr import extract
+
+    directory, file_name = download_doc(mtr_link, "mtr")
+    file_path = Path(directory) / file_name
+    result = extract(file_path)
+    if result is None:
+        logger.error("Failed to extract MTR")
+        return False
+
+    effective_date, sections = result
+    mtr = Mtr(
+        file_name=file_name,
+        creation_day=datetime.date.today(),
+        effective_date=effective_date,
+        sections=sections,
+    )
+    db.add(mtr)
+
+    logger.info("Bootstrapped MTR successfully")
+    return True
+
+
+def _bootstrap_ipg(db, ipg_link: str) -> bool:
+    """Download and insert the first IPG."""
+    _, file_name = download_doc(ipg_link, "ipg")
+    db.add(Ipg(creation_day=datetime.date.today(), file_name=file_name))
+
+    logger.info("Bootstrapped IPG successfully")
+    return True
+
+
+def bootstrap():
+    """
+    Bootstrap the database from scratch.
+
+    Idempotent: if the CR table already has data, exits early.
+    """
+    seed()
+
+    with SessionLocal() as db:
+        with db.begin():
+            existing = db.execute(select(Cr).limit(1)).scalar_one_or_none()
+            if existing:
+                logger.info("Database already has CR data, skipping bootstrap")
+                return
+
+    logger.info("Starting bootstrap — scraping current document links...")
+
+    cr_link = _scrape_cr_link()
+    if not cr_link:
+        logger.error("Could not find CR link, aborting bootstrap")
+        return
+
+    doc_links = _scrape_doc_links()
+
+    with SessionLocal() as db:
+        with db.begin():
+            # Seed redirects
+            _seed_redirect(db, "cr", cr_link)
+            for resource, link in doc_links.items():
+                _seed_redirect(db, resource, link)
+            logger.info("Seeded redirect links")
+
+            # Bootstrap CR (required)
+            if not _bootstrap_cr(db, cr_link):
+                logger.error("CR bootstrap failed, aborting")
+                return
+
+            # Bootstrap MTR (optional, needs Tika)
+            mtr_link = doc_links.get("mtr")
+            if mtr_link:
+                _bootstrap_mtr(db, mtr_link)
+            else:
+                logger.warning("No MTR link found, skipping MTR bootstrap")
+
+            # Bootstrap IPG (optional)
+            ipg_link = doc_links.get("ipg")
+            if ipg_link:
+                _bootstrap_ipg(db, ipg_link)
+            else:
+                logger.warning("No IPG link found, skipping IPG bootstrap")
+
+    logger.info("Bootstrap complete")

--- a/src/cli_scripts/run.py
+++ b/src/cli_scripts/run.py
@@ -21,6 +21,18 @@ def run(
     uvicorn.run("src.main:app", port=port, host=host, reload=reload)
 
 
+@app.command()
+def bootstrap():
+    """
+    Bootstrap the database from scratch. Downloads and parses the current
+    CR, MTR, and IPG from WotC and seeds the database. Idempotent — skips
+    if data already exists.
+    """
+    from src.cli_scripts.bootstrap import bootstrap as do_bootstrap
+
+    do_bootstrap()
+
+
 @app.callback()
 def options(
     envfile: Annotated[

--- a/src/cr/models.py
+++ b/src/cr/models.py
@@ -8,7 +8,7 @@ class Cr(Base):
     __tablename__ = "cr"
 
     id = Column(Integer, primary_key=True)
-    creation_day = Column(Date)
+    creation_day = Column(Date, index=True)
     set_code = Column(String(5))
     set_name = Column(String(50))
     data = Column(JSONB(astext_type=Text()))

--- a/src/cr/router.py
+++ b/src/cr/router.py
@@ -29,8 +29,7 @@ def get_all_rules(db: Session = Depends(get_db)):
     describing the part of the rule number after a comma, and `navigation`, which contains numbers of the previous
     and next rule in the document.
     """
-    rules = service.get_latest_cr(db)
-    return rules.data
+    return service.get_latest_cr_data(db)
 
 
 @router.get("/cr/keywords", summary="Keywords", response_model=schemas.KeywordDict, tags=[crTag.name])
@@ -64,8 +63,7 @@ def get_table_of_contents(db: Session = Depends(get_db)):
     The table of contents includes only numbered sections in the CR. That means it doesn't contain entries for the
     introduction, the glossary, or the credits.
     """
-    cr = service.get_latest_cr(db)
-    return cr.toc
+    return service.get_latest_cr_toc(db)
 
 
 @router.get(

--- a/src/cr/router.py
+++ b/src/cr/router.py
@@ -2,7 +2,7 @@ import os
 import re
 from typing import Dict, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 from thefuzz import fuzz, process
@@ -74,7 +74,6 @@ def get_table_of_contents(db: Session = Depends(get_db)):
     tags=[crTag.name],
 )
 def get_glossary_term(
-    response: Response,
     term: str = Path(description="Searched term in the glossary"),
     fuzzy: bool = Query(default=False, description="Use fuzzy matching to find the term."),
     unofficial: bool = Query(default=True, description="Include terms from the unofficial glossary"),
@@ -109,8 +108,7 @@ def get_glossary_term(
         found = entry is not None
 
     if not found:
-        response.status_code = 404
-        return {"detail": "Entry not found."}
+        raise HTTPException(404, {"detail": "Entry not found."})
 
     return {"term": entry["term"], "definition": entry["definition"]}
 
@@ -146,7 +144,6 @@ def get_unofficial():
     tags=[crTag.name],
 )
 def get_rule(
-    response: Response,
     rule_id: str = Path(description="Number of the rule you want to get"),
     find_definition: bool = Query(default=False, description="Redirect to actual definition for keywords."),
     db: Session = Depends(get_db),
@@ -166,8 +163,7 @@ def get_rule(
     """
     rule = service.get_rule(db, rule_id)
     if not rule:
-        response.status_code = 404
-        return {"detail": "Rule not found", "ruleNumber": rule_id}
+        raise HTTPException(404, {"detail": "Rule not found", "ruleNumber": rule_id})
 
     if find_definition:
         rule = get_best_rule(db, rule_id)
@@ -186,7 +182,6 @@ def get_rule(
 )
 @no422
 def get_examples(
-    response: Response,
     rule_id: str = Path(description="Number of the rule you want to get"),
     db: Session = Depends(get_db),
 ):
@@ -198,8 +193,7 @@ def get_examples(
     """
     rule = service.get_rule(db, rule_id)
     if not rule:
-        response.status_code = 404
-        return {"detail": "Rule not found", "ruleNumber": rule_id}
+        raise HTTPException(404, {"detail": "Rule not found", "ruleNumber": rule_id})
 
     return {"ruleNumber": rule_id, "examples": rule["examples"]}
 
@@ -277,7 +271,6 @@ def raw_latest_cr(db: Session = Depends(get_db)):
     tags=[filesTag.name],
 )
 def raw_cr_by_set_code(
-    response: Response,
     set_code: str = Path(description="Code of the requested set (case insensitive)", min_length=3, max_length=5),
     format: Union[FileFormat, None] = Query(default=FileFormat.any),
     db: Session = Depends(get_db),
@@ -290,12 +283,10 @@ def raw_cr_by_set_code(
     """
     cr = service.get_cr_by_set_code(db, set_code.upper())
     if not cr:
-        response.status_code = 404
-        return {"detail": "CR not available for this set"}
+        raise HTTPException(404, {"detail": "CR not available for this set"})
 
     if format != FileFormat.any and not re.search(r"\." + format + "$", cr.file_name):
-        response.status_code = 404
-        return {"detail": "CR for this set not available in specified format"}
+        raise HTTPException(404, {"detail": "CR for this set not available in specified format"})
 
     path = os.path.join(paths.cr_dir, cr.file_name)
     return FileResponse(path)

--- a/src/cr/router.py
+++ b/src/cr/router.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import Dict, Union
 
@@ -267,7 +268,7 @@ def raw_latest_cr(db: Session = Depends(get_db)):
     """
     cr = service.get_latest_cr(db)
     file_name = cr.file_name
-    path = "src/static/raw_docs/cr/" + file_name  # FIXME hardcoded path
+    path = os.path.join(paths.cr_dir, file_name)
     return FileResponse(path)
 
 
@@ -298,7 +299,7 @@ def raw_cr_by_set_code(
         response.status_code = 404
         return {"detail": "CR for this set not available in specified format"}
 
-    path = "src/static/raw_docs/cr/" + cr.file_name  # FIXME hardcoded path
+    path = os.path.join(paths.cr_dir, cr.file_name)
     return FileResponse(path)
 
 

--- a/src/cr/service.py
+++ b/src/cr/service.py
@@ -6,11 +6,38 @@ from src.cr.models import Cr
 from src.cr.schemas import Trace
 from src.diffs.models import CrDiff, CrDiffItem
 
+_cr_cache: dict | None = None
+_cr_toc_cache: list | None = None
+
 
 def get_latest_cr(db: Session) -> Cr:
     stmt = select(Cr).order_by(Cr.creation_day.desc()).limit(1)
     result = db.execute(stmt).scalars().first()
     return result
+
+
+def get_latest_cr_data(db: Session) -> dict | None:
+    global _cr_cache
+    if _cr_cache is None:
+        cr = get_latest_cr(db)
+        if cr:
+            _cr_cache = cr.data
+    return _cr_cache
+
+
+def get_latest_cr_toc(db: Session) -> list | None:
+    global _cr_toc_cache
+    if _cr_toc_cache is None:
+        cr = get_latest_cr(db)
+        if cr:
+            _cr_toc_cache = cr.toc
+    return _cr_toc_cache
+
+
+def invalidate_cr_cache():
+    global _cr_cache, _cr_toc_cache
+    _cr_cache = None
+    _cr_toc_cache = None
 
 
 def get_cr_by_set_code(db: Session, code: str) -> Cr | None:

--- a/src/cr/service.py
+++ b/src/cr/service.py
@@ -5,7 +5,6 @@ from src.cr import utils
 from src.cr.models import Cr
 from src.cr.schemas import Trace
 from src.diffs.models import CrDiff, CrDiffItem
-from src.diffs.schemas import CrDiffMetadata
 
 
 def get_latest_cr(db: Session) -> Cr:
@@ -48,22 +47,3 @@ def get_cr_trace_items(db: Session, rule_number: str) -> list[CrDiffItem] | None
 
     query = base_cte.union(recursive).select()
     return db.execute(select(CrDiffItem).from_statement(query)).scalars().fetchall()
-
-
-def get_trace_diff_metadata(diff_item: CrDiffItem) -> CrDiffMetadata:
-    diff = diff_item.diff
-    return CrDiffMetadata(
-        source_code=diff.source.set_code,
-        source_set=diff.source.set_name,
-        dest_code=diff.dest.set_code,
-        dest_set=diff.dest.set_name,
-    )
-
-
-def format_cr_change(db_item: CrDiffItem) -> dict:
-    item = {"old": None, "new": None}
-    if db_item.old_number:
-        item["old"] = {"ruleNum": db_item.old_number, "ruleText": db_item.old_text}
-    if db_item.new_number:
-        item["new"] = {"ruleNum": db_item.new_number, "ruleText": db_item.new_text}
-    return item

--- a/src/db.py
+++ b/src/db.py
@@ -1,16 +1,18 @@
 import os
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import URL
 from sqlalchemy.orm import sessionmaker
 
-_user = os.environ["DB_USER"]
-_pass = os.environ["DB_PASS"]
-_host = os.environ["DB_HOST"]
-_db = os.environ["DB_DATABASE"]
+SQLALCHEMY_DATABASE_URL = URL.create(
+    "postgresql+psycopg2",
+    username=os.environ["DB_USER"],
+    password=os.environ["DB_PASS"],
+    host=os.environ["DB_HOST"],
+    database=os.environ["DB_DATABASE"],
+)
 
-SQLALCHEMY_DATABASE_URL = f"postgresql+psycopg2://{_user}:{_pass}@{_host}/{_db}"
-
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True)
 
 SessionLocal = sessionmaker(bind=engine, future=True)
 

--- a/src/diffs/models.py
+++ b/src/diffs/models.py
@@ -11,7 +11,7 @@ class CrDiff(Base):
     __tablename__ = "cr_diffs"
 
     id = Column(Integer, primary_key=True)
-    creation_day = Column(Date, nullable=False)
+    creation_day = Column(Date, nullable=False, index=True)
     source_id = Column(ForeignKey("cr.id"), nullable=False)
     dest_id = Column(ForeignKey("cr.id"), nullable=False)
     bulletin_url = Column(Text)

--- a/src/diffs/router.py
+++ b/src/diffs/router.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Union
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -21,7 +21,6 @@ router = APIRouter(tags=[diffTag.name])
     responses={200: {"model": schemas.CRDiff}, 404: {"model": schemas.CrDiffError}},
 )
 def cr_diff(
-    response: Response,
     old: str | None = Query(None, description="Set code of the old set.", min_length=3, max_length=5),
     new: str | None = Query(None, description="Set code of the new set", min_length=3, max_length=5),
     nav: bool | None = Query(False, description="Flag to include the navigation data."),
@@ -55,12 +54,7 @@ def cr_diff(
 
     diff = service.get_cr_diff(db, old, new)
     if diff is None:
-        response.status_code = 404
-        return {
-            "detail": "No diff between these set codes found",
-            "old": old,
-            "new": new,
-        }
+        raise HTTPException(404, {"detail": "No diff between these set codes found", "old": old, "new": new})
 
     sorter = CRDiffSorter()
     changes = sorter.sort_diffs([service.format_cr_change(change) for change in diff.get_changes()])
@@ -136,11 +130,10 @@ def mtr_diff_metadata(db: Session = Depends(get_db)):
 
 
 @router.get("/pending/cr", include_in_schema=False, response_model=schemas.PendingCRDiffResponse)
-def cr_preview(response: Response, db: Session = Depends(get_db)):
+def cr_preview(db: Session = Depends(get_db)):
     diff: PendingCrDiff = service.get_pending_cr_diff(db)
     if not diff:
-        response.status_code = 404
-        return {"detail": "No diffs are pending"}
+        raise HTTPException(404, {"detail": "No diffs are pending"})
 
     return {"data": {"changes": diff.changes, "source_set": diff.source.set_name}}
 

--- a/src/extractor/cr/extract_cr.py
+++ b/src/extractor/cr/extract_cr.py
@@ -33,18 +33,15 @@ def extract(comp_rules: str):
 
     for index, section in enumerate(sections):
         currentSection = []
-        rules = re.findall(
-            r"^(\d{3}\.[^\s.]{1,4})[\s.]*(.*)"
-            "(?:\nExample: (.*))?(?:\nExample: (.*))?"
-            "(?:\nExample: (.*))?(?:\nExample: (.*))?",
-            section,
-            re.MULTILINE,
-        )
+        rule_pattern = re.compile(r"^(\d{3}\.[^\s.]{1,4})[\s.]*(.*)", re.MULTILINE)
+        rule_matches = list(rule_pattern.finditer(section))
+        rules = [(m.group(1), m.group(2)) for m in rule_matches]
         for idx, rule in enumerate(rules):
-            nonempty_examples = []
-            for ex in rule[2:5]:
-                if ex != "":
-                    nonempty_examples.append(ex)
+            # extract examples from text between this rule and the next
+            match_end = rule_matches[idx].end()
+            next_start = rule_matches[idx + 1].start() if idx + 1 < len(rule_matches) else len(section)
+            between = section[match_end:next_start]
+            nonempty_examples = re.findall(r"^Example: (.*)", between, re.MULTILINE)
             if len(nonempty_examples) == 0:
                 nonempty_examples = None
 

--- a/src/extractor/cr/refresh_cr.py
+++ b/src/extractor/cr/refresh_cr.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import re
 
 import requests
@@ -64,7 +65,7 @@ def download_cr(uri: str) -> tuple[str, str] | None:
 
     # save to file
     file_name = "cr-" + datetime.date.today().isoformat() + ".txt"
-    file_path = paths.cr_dir + "/" + file_name
+    file_path = os.path.join(paths.cr_dir, file_name)
     with open(file_path, "w", encoding="utf-8") as output:
         output.write(text)
     with open(paths.current_cr, "w", encoding="utf-8") as output:

--- a/src/extractor/download_doc.py
+++ b/src/extractor/download_doc.py
@@ -1,3 +1,4 @@
+import os
 from datetime import date
 from typing import Literal
 
@@ -5,12 +6,14 @@ import requests
 
 from src.resources import static_paths as paths
 
+_kind_dirs = {"mtr": paths.mtr_dir, "ipg": paths.ipg_dir}
+
 
 def download_doc(link: str, kind: Literal["mtr", "ipg"]):
 
-    directory = paths.docs_dir + "/" + kind
+    directory = _kind_dirs[kind]
     filename = kind + "-" + date.today().isoformat() + ".pdf"
-    filepath = directory + "/" + filename
+    filepath = os.path.join(directory, filename)
 
     r = requests.get(link, stream=True)
 

--- a/src/ipg/router.py
+++ b/src/ipg/router.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 from fastapi import APIRouter, Depends, Path, Response
 from fastapi.responses import FileResponse
@@ -7,6 +8,7 @@ from sqlalchemy.orm import Session
 from src.db import get_db
 from src.ipg import schemas, service
 from src.openapi.strings import filesTag
+from src.resources import static_paths as paths
 from src.schemas import Error
 
 router = APIRouter()
@@ -32,7 +34,7 @@ def raw_ipg_by_date(
         response.status_code = 404
         return {"detail": "IPG not available for this date"}
 
-    path = "src/static/raw_docs/ipg/" + ipg.file_name  # FIXME hardcoded path
+    path = os.path.join(paths.ipg_dir, ipg.file_name)
     return FileResponse(path)
 
 

--- a/src/ipg/router.py
+++ b/src/ipg/router.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-from fastapi import APIRouter, Depends, Path, Response
+from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -21,7 +21,7 @@ router = APIRouter()
     tags=[filesTag.name],
 )
 def raw_ipg_by_date(
-    response: Response, date: datetime.date = Path(description="Date of the IPG release"), db: Session = Depends(get_db)
+    date: datetime.date = Path(description="Date of the IPG release"), db: Session = Depends(get_db)
 ):
     """
     Returns a raw PDF file of the Infraction Procedure Guide released at the specified date.
@@ -31,8 +31,7 @@ def raw_ipg_by_date(
     """
     ipg = service.get_ipg_by_creation_date(db, date)
     if not ipg:
-        response.status_code = 404
-        return {"detail": "IPG not available for this date"}
+        raise HTTPException(404, {"detail": "IPG not available for this date"})
 
     path = os.path.join(paths.ipg_dir, ipg.file_name)
     return FileResponse(path)

--- a/src/link/router.py
+++ b/src/link/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -54,7 +54,7 @@ class LinkError(Error):
     summary="Other link",
     responses={307: {"content": None}, 404: {"description": "Link to resource does not exist.", "model": LinkError}},
 )
-def other_link(resource: str, response: Response, db: Session = Depends(get_db)):
+def other_link(resource: str, db: Session = Depends(get_db)):
     """
     Catchall route for other unofficial or undocumented redirects (e.g. the AIPG).
     See <https://mtgdoc.link> for the full list of supported values.
@@ -62,5 +62,4 @@ def other_link(resource: str, response: Response, db: Session = Depends(get_db))
     url = service.get_redirect(db, resource.lower())
     if url:
         return RedirectResponse(url)
-    response.status_code = 404
-    return {"detail": "Not found", "resource": resource}
+    raise HTTPException(404, {"detail": "Not found", "resource": resource})

--- a/src/main.py
+++ b/src/main.py
@@ -4,10 +4,11 @@ import uuid
 from contextlib import asynccontextmanager
 from typing import Any, Callable
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.admin.router import router as admin_router
 from src.cr.router import router as cr_router
@@ -51,6 +52,17 @@ app = FastAPI(
 )
 
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+class CacheControlMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if request.method == "GET" and not request.url.path.startswith("/admin"):
+            response.headers.setdefault("Cache-Control", "public, max-age=3600")
+        return response
+
+
+app.add_middleware(CacheControlMiddleware)
 
 app.include_router(admin_router)
 app.include_router(cr_router)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 from typing import Any, Callable
 
 from fastapi import FastAPI
@@ -29,6 +30,14 @@ from src.utils.scheduler import Scheduler
 
 logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    seeder.seed()
+    Scheduler().start()
+    yield
+
+
 app = FastAPI(
     title=strings.title,
     version="0.7.0",
@@ -38,6 +47,7 @@ app = FastAPI(
     contact=strings.contact_info,
     redoc_url="/docs",
     docs_url="/swagger",
+    lifespan=lifespan,
 )
 
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
@@ -48,8 +58,6 @@ app.include_router(mtr_router)
 app.include_router(ipg_router)
 app.include_router(link_router)
 app.include_router(diff_router)
-
-Scheduler().start()
 
 
 def compose_api_resolver() -> Callable[[], dict[str, Any]]:
@@ -64,11 +72,6 @@ def compose_api_resolver() -> Callable[[], dict[str, Any]]:
 
 
 app.openapi = compose_api_resolver()
-
-
-@app.on_event("startup")
-def seed():
-    seeder.seed()
 
 
 @app.exception_handler(RequestValidationError)

--- a/src/mtr/router.py
+++ b/src/mtr/router.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Response
+from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -88,7 +88,7 @@ def get_by_title(title: str, db: Session = Depends(get_db)):
     tags=[filesTag.name],
 )
 def raw_mtr_by_date(
-    response: Response, date: datetime.date = Path(description="Date of the MTR release"), db: Session = Depends(get_db)
+    date: datetime.date = Path(description="Date of the MTR release"), db: Session = Depends(get_db)
 ):
     """
     Returns a raw PDF file of the Magic Tournament Rules released at the specified date.
@@ -98,8 +98,7 @@ def raw_mtr_by_date(
     """
     mtr = service.get_mtr_by_date(db, date)
     if not mtr:
-        response.status_code = 404
-        return {"detail": "MTR not available for this date"}
+        raise HTTPException(404, {"detail": "MTR not available for this date"})
 
     path = os.path.join(paths.mtr_dir, mtr.file_name)
     return FileResponse(path)

--- a/src/mtr/router.py
+++ b/src/mtr/router.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Response
 from fastapi.responses import FileResponse
@@ -7,6 +8,7 @@ from sqlalchemy.orm import Session
 from src.db import get_db
 from src.mtr import schemas, service
 from src.openapi.strings import filesTag, mtrTag
+from src.resources import static_paths as paths
 from src.schemas import Error
 
 router = APIRouter()
@@ -99,7 +101,7 @@ def raw_mtr_by_date(
         response.status_code = 404
         return {"detail": "MTR not available for this date"}
 
-    path = "src/static/raw_docs/mtr/" + mtr.file_name  # FIXME hardcoded path
+    path = os.path.join(paths.mtr_dir, mtr.file_name)
     return FileResponse(path)
 
 

--- a/src/resources/seeder.py
+++ b/src/resources/seeder.py
@@ -15,6 +15,8 @@ def seed():
     logger.info("Making sure necessary directories exist...")
     seed_dir(paths.__dir)
     seed_dir(paths.cr_dir)
+    seed_dir(paths.mtr_dir)
+    seed_dir(paths.ipg_dir)
 
 
 if __name__ == "__main__":

--- a/src/resources/static_paths.py
+++ b/src/resources/static_paths.py
@@ -1,12 +1,15 @@
 import os
 
 __dir = os.path.dirname(__file__)
-__gen = __dir + "/generated"
-keyword_dict = __gen + "/keyword-dict.json"
-glossary_dict = __gen + "/glossary.json"
-structured_rules_dict = __gen + "/cr-structured.json"
-unofficial_glossary_dict = __dir + "/unofficial-glossary.json"
+__gen = os.path.join(__dir, "generated")
+keyword_dict = os.path.join(__gen, "keyword-dict.json")
+glossary_dict = os.path.join(__gen, "glossary.json")
+structured_rules_dict = os.path.join(__gen, "cr-structured.json")
+unofficial_glossary_dict = os.path.join(__dir, "unofficial-glossary.json")
 
-docs_dir = "src/static/raw_docs"
-cr_dir = "src/static/raw_docs/cr"
-current_cr = cr_dir + "/cr-current.txt"
+_src_dir = os.path.dirname(__dir)
+docs_dir = os.path.join(_src_dir, "static", "raw_docs")
+cr_dir = os.path.join(docs_dir, "cr")
+mtr_dir = os.path.join(docs_dir, "mtr")
+ipg_dir = os.path.join(docs_dir, "ipg")
+current_cr = os.path.join(cr_dir, "cr-current.txt")

--- a/src/utils/notifier.py
+++ b/src/utils/notifier.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import urllib.parse
 
 import requests
 
@@ -40,8 +39,7 @@ def notify_scrape_error(message):
 
 
 def _confirm_refresh_uri(doctype):
-    token = urllib.parse.quote(os.environ.get("ADMIN_KEY"), safe="")
-    return os.environ.get("BASE_URI", "") + f"/admin/update-link/{doctype}?token={token}"
+    return os.environ.get("BASE_URI", "") + f"/admin/update-link/{doctype}"
 
 
 def notify_new_cr(link):

--- a/src/utils/scheduler.py
+++ b/src/utils/scheduler.py
@@ -1,5 +1,5 @@
 from apscheduler.jobstores.memory import MemoryJobStore
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.schedulers.background import BackgroundScheduler
 
 from src.scraper.cr_scraper import scrape_rules_page
 from src.scraper.docs_scraper import scrape_docs_page
@@ -10,7 +10,7 @@ from src.utils.logger import logger
 class Scheduler:
     def __init__(self):
         job_store = MemoryJobStore()
-        self.scheduler = AsyncIOScheduler(jobstores={"default": job_store})
+        self.scheduler = BackgroundScheduler(jobstores={"default": job_store})
 
     def start(self):
         self.scheduler.start()


### PR DESCRIPTION
## Summary

- **Security**: Move admin auth to `Authorization: Bearer` header, bind Docker ports to localhost, use `URL.create()` for safe DB connection strings
- **Bootstrap**: Add zero-intervention CLI bootstrap command and Docker entrypoint with auto-migration + bootstrap
- **Bug fixes**: Move scheduler into FastAPI lifespan, fix hardcoded file paths, fix example extraction regex (was limited to 4), add error handling to admin confirmation, remove duplicate functions, fix blocking HTTP calls in async scheduler
- **Performance**: In-memory cache for CR data/ToC (invalidated on admin confirm), `Cache-Control: public, max-age=3600` middleware for all read-only endpoints, database indexes on `cr.creation_day` and `cr_diffs.creation_day`
- **Code quality**: Standardize all error responses to use `raise HTTPException` consistently

## Test plan

- [ ] Run `alembic upgrade head` to verify the new migration applies cleanly
- [ ] Run `python -m src.cli_scripts.run bootstrap` against a fresh database to verify zero-intervention seeding
- [ ] Verify admin endpoints require `Authorization: Bearer <token>` header
- [ ] Verify `/cr` and `/cr/toc` responses include `Cache-Control` header
- [ ] Verify `/cr` returns cached data on repeated requests
- [ ] Verify `/link/nonexistent` returns a proper HTTPException 404 JSON response
- [ ] Build and run via `docker compose up` to verify entrypoint runs migrations and bootstrap
